### PR TITLE
feat: add an option to include `git checkout -b` when copying

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,15 @@
             }
           ],
           "required": false
+        },
+        {
+          "name": "include-git-checkout-b",
+          "title": "Include Git Checkout Command",
+          "label": "Include `git checkout -b` when copying",
+          "description": "When enabled, the branch name will be prefixed with `git checkout -b`.",
+          "type": "checkbox",
+          "default": false,
+          "required": false
         }
       ]
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,18 @@ import { showHUD, Clipboard, getPreferenceValues } from "@raycast/api";
 interface Preferences {
   "branch-prefix"?: string;
   "suffix-length"?: string;
+  "include-git-checkout-b"?: boolean;
 }
 
 export default async function main() {
   const preferences = getPreferenceValues<Preferences>();
 
-  const prefix = preferences["branch-prefix"];
+  const prefix = preferences["branch-prefix"] ? preferences["branch-prefix"] + "/" : "";
   const length = parseInt(preferences["suffix-length"] || "4", 10);
+  const gitCheckoutB = preferences["include-git-checkout-b"] ? "git checkout -b " : "";
   const id = (Math.random() * 1e20).toString(36).substring(0, length);
 
-  await Clipboard.copy((prefix ? prefix + "/" : "") + id);
-  await showHUD("Copied branch name to clipboard");
+  const result = gitCheckoutB + prefix + id;
+  await Clipboard.copy(result);
+  await showHUD(`Copied to your clipboard: ${result}`);
 }


### PR DESCRIPTION
This PR added an option to include `git checkout -b` command when copying a random branch name to the clipboard.

#### Option Disabled

```
shu/1234
```

#### Option Enabled

```
git checkout -b shu/1234
```